### PR TITLE
Build the project when it is installed as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "link-watch": "plugin-kit link-watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "prepare": "husky install",
+    "prepare": "husky install && run-s build",
     "prepublishOnly": "run-s build",
     "watch": "pkg-utils watch --strict"
   },


### PR DESCRIPTION
In order to use this dependency directly from GitHub, we need to build the project when we run npm install on it.